### PR TITLE
Advantage Kit Gradle Build Issue Fixed. 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=permwrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=permwrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        String frcYear = '2023'
+        String frcYear = '2024'
         File frcHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')

--- a/vendordeps/AdvantageKit.json
+++ b/vendordeps/AdvantageKit.json
@@ -1,7 +1,7 @@
 {
     "fileName": "AdvantageKit.json",
     "name": "AdvantageKit",
-    "version": "3.0.0-beta-5",
+    "version": "3.0.0-beta-6",
     "uuid": "d820cc26-74e3-11ec-90d6-0242ac120003",
     "frcYear": "2024",
     "mavenUrls": [],
@@ -10,24 +10,24 @@
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "wpilib-shim",
-            "version": "3.0.0-beta-5"
+            "version": "3.0.0-beta-6"
         },
         {
             "groupId": "org.littletonrobotics.akit.junction",
             "artifactId": "junction-core",
-            "version": "3.0.0-beta-5"
+            "version": "3.0.0-beta-6"
         },
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-api",
-            "version": "3.0.0-beta-5"
+            "version": "3.0.0-beta-6"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "org.littletonrobotics.akit.conduit",
             "artifactId": "conduit-wpilibio",
-            "version": "3.0.0-beta-5",
+            "version": "3.0.0-beta-6",
             "skipInvalidPlatforms": false,
             "isJar": false,
             "validPlatforms": [

--- a/vendordeps/NavX.json
+++ b/vendordeps/NavX.json
@@ -2,6 +2,7 @@
     "fileName": "NavX.json",
     "name": "KauaiLabs_navX_FRC",
     "version": "2023.0.4",
+    "frcYear": "2024",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
     "mavenUrls": [
         "https://dev.studica.com/maven/release/2023/"

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,8 +1,8 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix (v5)",
-    "version": "5.30.2",
-    "frcYear": 2023,
+    "version": "5.31.0+23.2.2",
+    "frcYear": 2024,
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
         "https://maven.ctr-electronics.com/release/"
@@ -12,19 +12,19 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-java",
-            "version": "5.30.2"
+            "version": "5.31.0"
         },
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-java",
-            "version": "5.30.2"
+            "version": "5.31.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -48,9 +48,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -61,9 +61,9 @@
             "simMode": "hwsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -74,9 +74,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -87,9 +87,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -100,9 +100,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -113,9 +113,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -126,9 +126,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -139,9 +139,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -152,9 +152,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -165,9 +165,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -182,7 +182,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "wpiapi-cpp",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_Phoenix_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -197,7 +197,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "api-cpp",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_Phoenix",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -212,7 +212,7 @@
         {
             "groupId": "com.ctre.phoenix",
             "artifactId": "cci",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_PhoenixCCI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -225,9 +225,9 @@
             "simMode": "hwsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro",
+            "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -242,7 +242,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_Phoenix_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -257,7 +257,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "api-cpp-sim",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_PhoenixSim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -272,7 +272,7 @@
         {
             "groupId": "com.ctre.phoenix.sim",
             "artifactId": "cci-sim",
-            "version": "5.30.2",
+            "version": "5.31.0",
             "libName": "CTRE_PhoenixCCISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -285,9 +285,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -300,9 +300,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -315,9 +315,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -330,9 +330,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -345,9 +345,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -360,9 +360,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -375,9 +375,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -390,9 +390,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -405,9 +405,9 @@
             "simMode": "swsim"
         },
         {
-            "groupId": "com.ctre.phoenixpro.sim",
+            "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.1",
+            "version": "23.2.2",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/WPILibNewCommands.json
+++ b/vendordeps/WPILibNewCommands.json
@@ -1,37 +1,38 @@
 {
-  "fileName": "WPILibNewCommands.json",
-  "name": "WPILib-New-Commands",
-  "version": "1.0.0",
-  "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
-  "mavenUrls": [],
-  "jsonUrl": "",
-  "javaDependencies": [
+    "fileName": "WPILibNewCommands.json",
+    "name": "WPILib-New-Commands",
+    "version": "1.0.0",
+    "uuid": "111e20f7-815e-48f8-9dd6-e675ce75b266",
+    "frcYear": "2024",
+    "mavenUrls": [],
+    "jsonUrl": "",
+    "javaDependencies": [
       {
-          "groupId": "edu.wpi.first.wpilibNewCommands",
-          "artifactId": "wpilibNewCommands-java",
-          "version": "wpilib"
+        "groupId": "edu.wpi.first.wpilibNewCommands",
+        "artifactId": "wpilibNewCommands-java",
+        "version": "wpilib"
       }
-  ],
-  "jniDependencies": [],
-  "cppDependencies": [
+    ],
+    "jniDependencies": [],
+    "cppDependencies": [
       {
-          "groupId": "edu.wpi.first.wpilibNewCommands",
-          "artifactId": "wpilibNewCommands-cpp",
-          "version": "wpilib",
-          "libName": "wpilibNewCommands",
-          "headerClassifier": "headers",
-          "sourcesClassifier": "sources",
-          "sharedLibrary": true,
-          "skipInvalidPlatforms": true,
-          "binaryPlatforms": [
-              "linuxathena",
-              "linuxarm32",
-              "linuxarm64",
-              "windowsx86-64",
-              "windowsx86",
-              "linuxx86-64",
-              "osxuniversal"
-          ]
+        "groupId": "edu.wpi.first.wpilibNewCommands",
+        "artifactId": "wpilibNewCommands-cpp",
+        "version": "wpilib",
+        "libName": "wpilibNewCommands",
+        "headerClassifier": "headers",
+        "sourcesClassifier": "sources",
+        "sharedLibrary": true,
+        "skipInvalidPlatforms": true,
+        "binaryPlatforms": [
+          "linuxathena",
+          "linuxarm32",
+          "linuxarm64",
+          "windowsx86-64",
+          "windowsx86",
+          "linuxx86-64",
+          "osxuniversal"
+        ]
       }
-  ]
-}
+    ]
+  }


### PR DESCRIPTION
- **Incorrect Gradle Version** -- As determined through looking through example project the team that builds AdvantageKit used Gradle 8.4 as their version. There were issue with Gradle not having access to libraries because they didn't exist in that version of Gradle that our code was built with originally. Through changing the Gradle version in gradle.properties file this was resolved. 
- **Lack of frcYear Variable**-- For some weird reason none of the vendor libraries had the variable frcYear in them which is required for the build to work, and since for this we're using WPILib 2024.1.1-beta-4 these all had to be updated to frcYear="2024".

